### PR TITLE
Made length of A/B-Qs a BOOM parameter

### DIFF
--- a/src/main/scala/common/config-mixins.scala
+++ b/src/main/scala/common/config-mixins.scala
@@ -219,7 +219,7 @@ class WithSliceBooms extends Config((site, here, up) => {
       fpu = None,
       useAtomics = true,
       usingFPU = false,
-      loadSliceMode = true,
+      loadSliceCore = Some(LoadSliceCoreParams(numAqEntries = 8, numBqEntries = 8))
     ),
     dcache = Some(DCacheParams(rowBits = site(SystemBusKey).beatBits,
                                nSets=64, nWays=4, nMSHRs=2, nTLBEntries=8)),

--- a/src/main/scala/common/consts.scala
+++ b/src/main/scala/common/consts.scala
@@ -27,7 +27,7 @@ trait BOOMDebugConstants
   val DEBUG_PRINTF        = false // use the Chisel printf functionality
   val COMMIT_LOG_PRINTF   = false // dump commit state, for comparision against ISA sim
   val MEMTRACE_PRINTF     = false // dump trace of memory accesses to L1D for debugging
-  val O3PIPEVIEW_PRINTF   = false // dump trace for O3PipeView from gem5
+  val O3PIPEVIEW_PRINTF   = true // dump trace for O3PipeView from gem5
   val O3_CYCLE_TIME       = (1000)// "cycle" time expected by o3pipeview.py
 
   // When enabling DEBUG_PRINTF, the vertical whitespace can be padded out

--- a/src/main/scala/common/consts.scala
+++ b/src/main/scala/common/consts.scala
@@ -27,7 +27,7 @@ trait BOOMDebugConstants
   val DEBUG_PRINTF        = false // use the Chisel printf functionality
   val COMMIT_LOG_PRINTF   = false // dump commit state, for comparision against ISA sim
   val MEMTRACE_PRINTF     = false // dump trace of memory accesses to L1D for debugging
-  val O3PIPEVIEW_PRINTF   = true // dump trace for O3PipeView from gem5
+  val O3PIPEVIEW_PRINTF   = false // dump trace for O3PipeView from gem5
   val O3_CYCLE_TIME       = (1000)// "cycle" time expected by o3pipeview.py
 
   // When enabling DEBUG_PRINTF, the vertical whitespace can be padded out

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -83,9 +83,8 @@ case class BoomCoreParams(
   useRVE: Boolean = false,
   useBPWatch: Boolean = false,
   clockGate: Boolean = false,
-  loadSliceMode: Boolean = false,
-  numAqEntries: Int = 8,
-  numBqEntries: Int = 8
+  loadSliceCore: Option[LoadSliceCoreParams] = None
+
 ) extends freechips.rocketchip.tile.CoreParams
 {
   val haveFSDirty = false
@@ -264,8 +263,6 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
   val stqAddrSz       = log2Ceil(numStqEntries)
   val lsuAddrSz       = ldqAddrSz max stqAddrSz
   val brTagSz         = log2Ceil(maxBrCount)
-  val aqAddrSz        = log2Ceil(numAqEntries)
-  val bqAddrSz        = log2Ceil(numBqEntries)
 
   require (numIntPhysRegs >= (32 + coreWidth))
   require (numFpPhysRegs >= (32 + coreWidth))
@@ -285,3 +282,10 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
   val corePAddrBits = paddrBits
   val corePgIdxBits = pgIdxBits
 }
+
+// Case class for LoadSliceCore parameters.
+//  TODO: Consider moving this to separate file?
+case class LoadSliceCoreParams(
+  numAqEntries: Int = 8,
+  numBqEntries: Int = 8
+                          )

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -148,8 +148,6 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
   val numRcqEntries = boomParams.numRCQEntries       // number of RoCC commit queue entries. This can be large since it just keeps a pdst
   val numLdqEntries = boomParams.numLdqEntries       // number of LAQ entries
   val numStqEntries = boomParams.numStqEntries       // number of SAQ/SDQ entries
-  val numAqEntries  = boomParams.numAqEntries        // number of A-Q entries
-  val numBqEntries  = boomParams.numBqEntries        // number of Bypass-Q entries
   val maxBrCount    = boomParams.maxBrCount          // number of branches we can speculate simultaneously
   val ftqSz         = boomParams.ftq.nEntries        // number of FTQ entries
   val numFetchBufferEntries = boomParams.numFetchBufferEntries // number of instructions that stored between fetch&decode

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -83,7 +83,9 @@ case class BoomCoreParams(
   useRVE: Boolean = false,
   useBPWatch: Boolean = false,
   clockGate: Boolean = false,
-  loadSliceMode: Boolean = false
+  loadSliceMode: Boolean = false,
+  numAqEntries: Int = 8,
+  numBqEntries: Int = 8
 ) extends freechips.rocketchip.tile.CoreParams
 {
   val haveFSDirty = false
@@ -147,6 +149,8 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
   val numRcqEntries = boomParams.numRCQEntries       // number of RoCC commit queue entries. This can be large since it just keeps a pdst
   val numLdqEntries = boomParams.numLdqEntries       // number of LAQ entries
   val numStqEntries = boomParams.numStqEntries       // number of SAQ/SDQ entries
+  val numAqEntries  = boomParams.numAqEntries        // number of A-Q entries
+  val numBqEntries  = boomParams.numBqEntries        // number of Bypass-Q entries
   val maxBrCount    = boomParams.maxBrCount          // number of branches we can speculate simultaneously
   val ftqSz         = boomParams.ftq.nEntries        // number of FTQ entries
   val numFetchBufferEntries = boomParams.numFetchBufferEntries // number of instructions that stored between fetch&decode
@@ -260,6 +264,8 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
   val stqAddrSz       = log2Ceil(numStqEntries)
   val lsuAddrSz       = ldqAddrSz max stqAddrSz
   val brTagSz         = log2Ceil(maxBrCount)
+  val aqAddrSz        = log2Ceil(numAqEntries)
+  val bqAddrSz        = log2Ceil(numBqEntries)
 
   require (numIntPhysRegs >= (32 + coreWidth))
   require (numFpPhysRegs >= (32 + coreWidth))

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -107,7 +107,7 @@ class BoomCore(implicit p: Parameters) extends BoomModule
   val rename_stages    = if (usingFPU) Seq(rename_stage, fp_rename_stage) else Seq(rename_stage)
 
   val issue_units      = new boom.exu.IssueUnits(numIntIssueWakeupPorts)
-  val dispatcher       = if(boomParams.loadSliceMode) Module(new SliceDispatcher) else Module(new BasicDispatcher)
+  val dispatcher       = if(boomParams.loadSliceCore.isDefined) Module(new SliceDispatcher) else Module(new BasicDispatcher)
 
   val iregfile         = Module(new RegisterFileSynthesizable(
                              numIntPhysRegs,
@@ -617,7 +617,7 @@ class BoomCore(implicit p: Parameters) extends BoomModule
     dispatcher.io.ren_uops(w).bits  := dis_uops(w)
   }
   // connect dispatch to busy table in LSC mode
-  if(boomParams.loadSliceMode){
+  if(boomParams.loadSliceCore.isDefined){
     rename_stage.io.slice_busy_req_uops.get := dispatcher.io.slice_busy_req_uops.get
     dispatcher.io.slice_busy_resps.get := rename_stage.io.slice_busy_resps.get
     dispatcher.io.slice_brinfo.get := br_unit.brinfo
@@ -1321,7 +1321,7 @@ class BoomCore(implicit p: Parameters) extends BoomModule
       when (dec_fire(w)) {
         printf("%d; O3PipeView:rename: %d\n", dec_uops(w).debug_events.fetch_seq, debug_tsc_reg)
       }
-      if(!boomParams.loadSliceMode){
+      if(!boomParams.loadSliceCore.isDefined){
         when (dispatcher.io.ren_uops(w).valid) {
           printf("%d; O3PipeView:dispatch: %d\n", dispatcher.io.ren_uops(w).bits.debug_events.fetch_seq, debug_tsc_reg)
         }

--- a/src/main/scala/exu/dispatch.scala
+++ b/src/main/scala/exu/dispatch.scala
@@ -86,8 +86,8 @@ class SliceDispatcher(implicit p: Parameters) extends Dispatcher
   val a_issue_blocked = !a_mem_dispatch.ready || !a_int_dispatch.ready // something from a is in a issue slot
   val b_issue_blocked = !b_mem_dispatch.ready || !b_int_dispatch.ready
 
-  val a_queue = Module(new SliceDispatchQueue(qName = "a_queue"))
-  val b_queue = Module(new SliceDispatchQueue(qName = "b_queue"))
+  val a_queue = Module(new SliceDispatchQueue(numEntries = boomParams.numAqEntries, qName = "a_queue"))
+  val b_queue = Module(new SliceDispatchQueue(numEntries = boomParams.numBqEntries, qName = "b_queue"))
   a_queue.io.flush := io.slice_flush.get
   b_queue.io.flush := io.slice_flush.get
   a_queue.io.brinfo := io.slice_brinfo.get
@@ -257,7 +257,6 @@ class CompactingDispatcher(implicit p: Parameters) extends Dispatcher
 
 class SliceDispatchQueue(
                         val numEntries: Int = 8,
-                        val qAddrSz: Int = 3,
                         val qName: String
                         )(implicit p: Parameters) extends BoomModule
 {
@@ -270,6 +269,8 @@ class SliceDispatchQueue(
     val flush = Input(new Bool)
     val tsc_reg = Input(UInt(width=xLen.W)) // needed for pipeview
   })
+
+  val qAddrSz: Int = log2Ceil(numEntries)
 
   // Maps i to idx of queue. Used with for-loops starting at head or tail
   def wrapIndex(i: UInt): UInt = {

--- a/src/main/scala/exu/dispatch.scala
+++ b/src/main/scala/exu/dispatch.scala
@@ -28,11 +28,11 @@ class DispatchIO(implicit p: Parameters) extends BoomBundle
   // dispatchWidth may vary between issue queues
   val dis_uops = MixedVec(issueParams.map(ip=>Vec(ip.dispatchWidth, DecoupledIO(new MicroOp))))
   // io for busy table - used only for LSC
-  val slice_busy_req_uops = if(boomParams.loadSliceMode) Some(Output(Vec(coreWidth, new MicroOp))) else None
-  val slice_busy_resps = if(boomParams.loadSliceMode) Some(Input(Vec(coreWidth, new BusyResp))) else None
+  val slice_busy_req_uops = if(boomParams.loadSliceCore.isDefined) Some(Output(Vec(coreWidth, new MicroOp))) else None
+  val slice_busy_resps = if(boomParams.loadSliceCore.isDefined) Some(Input(Vec(coreWidth, new BusyResp))) else None
   // brinfo & flush for LSC
-  val slice_brinfo = if(boomParams.loadSliceMode) Some(Input(new BrResolutionInfo())) else None
-  val slice_flush = if(boomParams.loadSliceMode) Some(Input(Bool())) else None
+  val slice_brinfo = if(boomParams.loadSliceCore.isDefined) Some(Input(new BrResolutionInfo())) else None
+  val slice_flush = if(boomParams.loadSliceCore.isDefined) Some(Input(Bool())) else None
 
   val tsc_reg = Input(UInt(width=xLen.W))
 }
@@ -86,8 +86,8 @@ class SliceDispatcher(implicit p: Parameters) extends Dispatcher
   val a_issue_blocked = !a_mem_dispatch.ready || !a_int_dispatch.ready // something from a is in a issue slot
   val b_issue_blocked = !b_mem_dispatch.ready || !b_int_dispatch.ready
 
-  val a_queue = Module(new SliceDispatchQueue(numEntries = boomParams.numAqEntries, qName = "a_queue"))
-  val b_queue = Module(new SliceDispatchQueue(numEntries = boomParams.numBqEntries, qName = "b_queue"))
+  val a_queue = Module(new SliceDispatchQueue(numEntries = boomParams.loadSliceCore.get.numAqEntries, qName = "a_queue"))
+  val b_queue = Module(new SliceDispatchQueue(numEntries = boomParams.loadSliceCore.get.numBqEntries, qName = "b_queue"))
   a_queue.io.flush := io.slice_flush.get
   b_queue.io.flush := io.slice_flush.get
   a_queue.io.brinfo := io.slice_brinfo.get

--- a/src/main/scala/exu/issue-units/issue-unit.scala
+++ b/src/main/scala/exu/issue-units/issue-unit.scala
@@ -125,7 +125,7 @@ abstract class IssueUnit(
       // For StoreAddrGen for Int, or AMOAddrGen, we go to addr gen state
       when ((io.dis_uops(w).bits.uopc === uopSTA && io.dis_uops(w).bits.lrs2_rtype === RT_FIX) ||
              io.dis_uops(w).bits.uopc === uopAMO_AG) {
-        if(boomParams.loadSliceMode) {
+        if(boomParams.loadSliceCore.isDefined) {
           dis_uops(w).iw_state := s_valid_1 // Dont do the store splitting in the same Issue Slot
         } else {
           dis_uops(w).iw_state := s_valid_2

--- a/src/main/scala/exu/issue-units/issue-units.scala
+++ b/src/main/scala/exu/issue-units/issue-units.scala
@@ -54,7 +54,7 @@ class IssueUnits(val numWakeupPorts: Int)(implicit val p: Parameters)
 
   // create the issue units (note: this does not create the fp issue unit)
   for (issueParam <- issueParams.filter(_.iqType != IQT_FP.litValue)) {
-    val issue_unit: IssueUnit = if(boomParams.loadSliceMode){
+    val issue_unit: IssueUnit = if(boomParams.loadSliceCore.isDefined){
       Module(new IssueUnitSlice(issueParam, numWakeupPorts))
     } else{
       Module(new IssueUnitCollapsing(issueParam, numWakeupPorts))

--- a/src/main/scala/exu/rename/rename-stage.scala
+++ b/src/main/scala/exu/rename/rename-stage.scala
@@ -70,8 +70,8 @@ class RenameStageIO(
   val debug = Output(new DebugRenameStageIO(numPhysRegs))
 
   require(coreWidth == plWidth) // make sure we can use coreWidth and plWidth interchangeably
-  val slice_busy_req_uops = if(boomParams.loadSliceMode) Some(Input(Vec(coreWidth, new MicroOp))) else None
-  val slice_busy_resps = if(boomParams.loadSliceMode) Some(Output(Vec(coreWidth, new BusyResp))) else None
+  val slice_busy_req_uops = if(boomParams.loadSliceCore.isDefined) Some(Input(Vec(coreWidth, new MicroOp))) else None
+  val slice_busy_resps = if(boomParams.loadSliceCore.isDefined) Some(Output(Vec(coreWidth, new BusyResp))) else None
 }
 
 /**
@@ -293,7 +293,7 @@ class RenameStage(
   busytable.io.wb_valids := io.wakeups.map(_.valid)
   busytable.io.wb_pdsts := io.wakeups.map(_.bits.uop.pdst)
 
-  if(boomParams.loadSliceMode) {
+  if(boomParams.loadSliceCore.isDefined) {
     busytable.io.req_uops := io.slice_busy_req_uops.get
     io.slice_busy_resps.get := busytable.io.busy_resps
   } else {


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**:  other enhancement

<!-- choose one -->
**Impact**: no rtl change 

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
Made the lenghts of A and B-queues in the Slice Dispatcher parameterizable from the BoomCoreParams