### PR TITLE
Lsc dev tag

### DIFF
--- a/src/main/scala/common/config-mixins.scala
+++ b/src/main/scala/common/config-mixins.scala
@@ -219,7 +219,7 @@ class WithSliceBooms extends Config((site, here, up) => {
       fpu = Some(freechips.rocketchip.tile.FPUParams(sfmaLatency=4, dfmaLatency=4, divSqrt=true)),
       useAtomics = true,
       usingFPU = true,
-      loadSliceCore = Some(LoadSliceCoreParams(numAqEntries = 8, numBqEntries = 8, ibdaTag = IBDA_TAG_FULL_PC))
+      loadSliceCore = Some(LoadSliceCoreParams(numAqEntries = 8, numBqEntries = 8, ibdaTagType = IBDA_TAG_UOPC_LOB))
     ),
     dcache = Some(DCacheParams(rowBits = site(SystemBusKey).beatBits,
                                nSets=64, nWays=4, nMSHRs=2, nTLBEntries=8)),

--- a/src/main/scala/common/config-mixins.scala
+++ b/src/main/scala/common/config-mixins.scala
@@ -219,7 +219,7 @@ class WithSliceBooms extends Config((site, here, up) => {
       fpu = Some(freechips.rocketchip.tile.FPUParams(sfmaLatency=4, dfmaLatency=4, divSqrt=true)),
       useAtomics = true,
       usingFPU = true,
-      loadSliceCore = Some(LoadSliceCoreParams(numAqEntries = 8, numBqEntries = 8))
+      loadSliceCore = Some(LoadSliceCoreParams(numAqEntries = 8, numBqEntries = 8, ibdaTag = IBDA_TAG_FULL_PC))
     ),
     dcache = Some(DCacheParams(rowBits = site(SystemBusKey).beatBits,
                                nSets=64, nWays=4, nMSHRs=2, nTLBEntries=8)),

--- a/src/main/scala/common/consts.scala
+++ b/src/main/scala/common/consts.scala
@@ -413,4 +413,7 @@ trait LoadSliceCoreConstants
 
   val IstFtqPortIdx = 0
   val RdtFtqPortIdx = 2
+
+  val IBDA_TAG_FULL_PC = 0
+  val IBDA_TAG_UOPC_LOB = 1
 }

--- a/src/main/scala/common/consts.scala
+++ b/src/main/scala/common/consts.scala
@@ -416,4 +416,5 @@ trait LoadSliceCoreConstants
 
   val IBDA_TAG_FULL_PC = 0
   val IBDA_TAG_UOPC_LOB = 1
+  val IBDA_TAG_INST_LOB = 2
 }

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -305,7 +305,8 @@ case class DromajoParams(
 //  TODO: Consider moving this to separate file?
 case class LoadSliceCoreParams(
   numAqEntries: Int = 8,
-  numBqEntries: Int = 8
+  numBqEntries: Int = 8,
+  ibdaTag: Int = IBDA_TAG_FULL_PC
 
                           )
 

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -306,25 +306,12 @@ case class DromajoParams(
 case class LoadSliceCoreParams(
   numAqEntries: Int = 8,
   numBqEntries: Int = 8,
-  ibdaTag: Int = IBDA_TAG_FULL_PC
-                          )(implicit p: Parameters) extends HasTileParameters with HasBoomCoreParameters
-{
-  // Calculate the size of the tag based on the config chosen in config-mixin.scala
-  val ibdaTagSz = ibdaTag match {
-    case IBDA_TAG_FULL_PC => vaddrBitsExtended
-    case IBDA_TAG_UOPC_LOB => UOPC_SZ + log2Ceil(icBlockBytes) //uopc + pc_lob
-    case IBDA_TAG_INST_LOB => 32 + log2Ceil(icBlockBytes) //inst + pc_lob
-  }
-
-  // Create function that extracts the tag from a MicroOp
-  def ibda_get_tag(uop: MicroOp): UInt = {
-   val tag = UInt(ibdaTagSz.W)
-    if(ibdaTag == IBDA_TAG_FULL_PC) tag := uop.debug_pc
-    else if (ibdaTag == IBDA_TAG_UOPC_LOB) tag := Cat(uop.uopc, uop.pc_lob)
-    else if (ibdaTag == IBDA_TAG_INST_LOB) tag := Cat(uop.inst, uop.pc_lob)
-    tag
+  ibdaTagType: Int = IBDA_TAG_FULL_PC
+                          ) {
+  val ibdaTagSz = ibdaTagType match {
+    case IBDA_TAG_FULL_PC => 40
+    case IBDA_TAG_UOPC_LOB => UOPC_SZ + 6 //uopc + pc_lob
+    case IBDA_TAG_INST_LOB => 32 + 6 //inst + pc_lob
   }
 
 }
-
-

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -307,11 +307,7 @@ case class LoadSliceCoreParams(
   numAqEntries: Int = 8,
   numBqEntries: Int = 8,
   ibdaTagType: Int = IBDA_TAG_FULL_PC
-                          ) {
-  val ibdaTagSz = ibdaTagType match {
-    case IBDA_TAG_FULL_PC => 40
-    case IBDA_TAG_UOPC_LOB => UOPC_SZ + 6 //uopc + pc_lob
-    case IBDA_TAG_INST_LOB => 32 + 6 //inst + pc_lob
-  }
+                              ) {
+
 
 }

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -307,7 +307,24 @@ case class LoadSliceCoreParams(
   numAqEntries: Int = 8,
   numBqEntries: Int = 8,
   ibdaTag: Int = IBDA_TAG_FULL_PC
+                          )(implicit p: Parameters) extends HasTileParameters with HasBoomCoreParameters
+{
+  // Calculate the size of the tag based on the config chosen in config-mixin.scala
+  val ibdaTagSz = ibdaTag match {
+    case IBDA_TAG_FULL_PC => vaddrBitsExtended
+    case IBDA_TAG_UOPC_LOB => UOPC_SZ + log2Ceil(icBlockBytes) //uopc + pc_lob
+    case IBDA_TAG_INST_LOB => 32 + log2Ceil(icBlockBytes) //inst + pc_lob
+  }
 
-                          )
+  // Create function that extracts the tag from a MicroOp
+  def ibda_get_tag(uop: MicroOp): UInt = {
+   val tag = UInt(ibdaTagSz.W)
+    if(ibdaTag == IBDA_TAG_FULL_PC) tag := uop.debug_pc
+    else if (ibdaTag == IBDA_TAG_UOPC_LOB) tag := Cat(uop.uopc, uop.pc_lob)
+    else if (ibdaTag == IBDA_TAG_INST_LOB) tag := Cat(uop.inst, uop.pc_lob)
+    tag
+  }
+
+}
 
 

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -44,6 +44,7 @@ import boom.exu.FUConstants._
 import boom.common.BoomTilesKey
 import boom.util.{RobTypeToChars, BoolToChar, GetNewUopAndBrMask, Sext, WrapInc, BoomCoreStringPrefix, DromajoCosimBlackBox, AlignPCToBoundary}
 import lsc.{InstructionSliceTable, RegisterDependencyTable}
+import lsc.IbdaParams
 
 
 /**
@@ -624,26 +625,40 @@ class BoomCore(implicit p: Parameters) extends BoomModule
   //-------------------------------------------------------------
   // Dispatch to issue queues
 
-  // ist lookup
+  /**
+    * IBDA stuff
+    *
+    */
 
-  if(boomParams.loadSliceMode) {
-    // Unwrap port to FTQ
-    val get_pc_slice = io.ifu.get_pc_slice.get
-    for (w <- 0 until coreWidth) {
-      // Access only IST ports
-      val idx = w + IstFtqPortIdx
-      // Request fetch_pc from FTQ
-      get_pc_slice(idx).ftq_idx := dis_uops(w).ftq_idx
-      // Recreate PC for dispatched uop
-      val block_pc = AlignPCToBoundary(get_pc_slice(idx).fetch_pc, icBlockBytes)
-      val pc = (block_pc | dis_uops(w).pc_lob) - Mux(dis_uops(w).edge_inst, 2.U, 0.U)
-      ist.get.io.check(w).addr.valid := dis_fire(w)
-      ist.get.io.check(w).addr.bits := pc
-      dis_uops(w).is_lsc_b := ist.get.io.check(w).in_ist
+  // Calculate the size of the tag based on the config chosen in config-mixin.scala
+  if (boomParams.loadSliceMode) {
 
-      assert(!(dis_fire(w) && (dis_uops(w).debug_pc =/= pc)), "[IST] debug_pc and fetch_pc mismatch")
+    // If we want the Full PC we need FTQ ports and etc. This is not
+    //  the preferred way since we need so many ports to FTQ
+    if (boomParams.loadSliceCore.get.ibdaTagType == IBDA_TAG_FULL_PC) {
+      val get_pc_slice = io.ifu.get_pc_slice.get
+      for (w <- 0 until coreWidth) {
+        // Access only IST ports
+        val idx = w + IstFtqPortIdx
+        // Request fetch_pc from FTQ
+        get_pc_slice(idx).ftq_idx := dis_uops(w).ftq_idx
+        // Recreate PC for dispatched uop
+        val block_pc = AlignPCToBoundary(get_pc_slice(idx).fetch_pc, icBlockBytes)
+        val pc = (block_pc | dis_uops(w).pc_lob) - Mux(dis_uops(w).edge_inst, 2.U, 0.U)
+        ist.get.io.check(w).tag.valid := dis_fire(w)
+        ist.get.io.check(w).tag.bits := pc
+        dis_uops(w).is_lsc_b := ist.get.io.check(w).in_ist
+
+        assert(!(dis_fire(w) && (dis_uops(w).debug_pc =/= pc)), "[IST] debug_pc and fetch_pc mismatch")
+      }
+    } else {
+      // We dont want the full PC but rather some hash of the UOP.
+      //  The hash itself is chosen in the ibda_get_tag function defined above
+      for (w <- 0 until coreWidth) {
+        ist.get.io.check(w).tag.valid := dis_fire(w)
+        ist.get.io.check(w).tag.bits := IbdaParams.ibda_get_tag(dis_uops(w))
+      }
     }
-
 
   }
 
@@ -1152,22 +1167,30 @@ class BoomCore(implicit p: Parameters) extends BoomModule
 
   if (boomParams.loadSliceMode) {
     // Connect RDT and IST and forward the commit signals from ROB to RDT
+
     ist.get.io.mark := rdt.get.io.mark
     rdt.get.io.commit.rob := rob.io.commit
 
-    // Unwrap port to FTQ
-    val get_pc_slice = io.ifu.get_pc_slice.get
-    for (w <- 0 until retireWidth) {
-      val idx = w + RdtFtqPortIdx
-      // Request fetch_pc from ftq_idx
-      get_pc_slice(idx).ftq_idx := rob.io.commit.uops(w).ftq_idx
-      // Recreate PC of this instruction
-      val block_pc = AlignPCToBoundary(get_pc_slice(idx).fetch_pc, icBlockBytes)
-      val pc = (block_pc | rob.io.commit.uops(w).pc_lob) - Mux(rob.io.commit.uops(w).edge_inst, 2.U, 0.U)
-      rdt.get.io.commit.pc(w) := pc
+    if (boomParams.loadSliceCore.get.ibdaTagType == IBDA_TAG_FULL_PC) {
+      // Unwrap port to FTQ
+      val get_pc_slice = io.ifu.get_pc_slice.get
+      for (w <- 0 until retireWidth) {
+        val idx = w + RdtFtqPortIdx
+        // Request fetch_pc from ftq_idx
+        get_pc_slice(idx).ftq_idx := rob.io.commit.uops(w).ftq_idx
+        // Recreate PC of this instruction
+        val block_pc = AlignPCToBoundary(get_pc_slice(idx).fetch_pc, icBlockBytes)
+        val pc = (block_pc | rob.io.commit.uops(w).pc_lob) - Mux(rob.io.commit.uops(w).edge_inst, 2.U, 0.U)
+        rdt.get.io.commit.tag(w) := pc
 
-      assert(!(rob.io.commit.valids(w) && (pc =/= rob.io.commit.uops(w).debug_pc)), "[RDT] fetch_pc and debug_pc mismatch")
+        assert(!(rob.io.commit.valids(w) && (pc =/= rob.io.commit.uops(w).debug_pc)), "[RDT] fetch_pc and debug_pc mismatch")
+      }
+    } else {
+      for (w <- 0 until retireWidth) {
+        rdt.get.io.commit.tag(w) := IbdaParams.ibda_get_tag(rob.io.commit.uops(w))
+      }
     }
+
   }
 
 

--- a/src/main/scala/ifu/fetch-control-unit.scala
+++ b/src/main/scala/ifu/fetch-control-unit.scala
@@ -92,7 +92,7 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
 
     val br_unit           = Input(new BranchUnitResp())
     val get_pc            = new GetPCFromFtqIO()
-    val get_pc_slice      = if(boomParams.loadSliceCore.map(_.ibdaTag == IBDA_TAG_FULL_PC).getOrElse(false)) Some(Vec(coreWidth*2, new GetPCSlice())) else None
+    val get_pc_slice      = if(boomParams.loadSliceCore.map(_.ibdaTagType == IBDA_TAG_FULL_PC).getOrElse(false)) Some(Vec(coreWidth*2, new GetPCSlice())) else None
 
     // Breakpoint info
     val status            = Input(new MStatus)

--- a/src/main/scala/ifu/fetch-control-unit.scala
+++ b/src/main/scala/ifu/fetch-control-unit.scala
@@ -92,7 +92,7 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
 
     val br_unit           = Input(new BranchUnitResp())
     val get_pc            = new GetPCFromFtqIO()
-    val get_pc_slice      = if(boomParams.loadSliceMode) Some(Vec(coreWidth*2, new GetPCSlice())) else None
+    val get_pc_slice      = if(boomParams.loadSliceCore.map(_.ibdaTag == IBDA_TAG_FULL_PC).getOrElse(false)) Some(Vec(coreWidth*2, new GetPCSlice())) else None
 
     // Breakpoint info
     val status            = Input(new MStatus)

--- a/src/main/scala/ifu/fetch-target-queue.scala
+++ b/src/main/scala/ifu/fetch-target-queue.scala
@@ -109,7 +109,7 @@ class FetchTargetQueue(num_entries: Int)(implicit p: Parameters) extends BoomMod
 
     // Give PC info to BranchUnit.
     val get_ftq_pc = new GetPCFromFtqIO()
-    val get_pc_slice = if (boomParams.loadSliceCore.map(_.ibdaTag == IBDA_TAG_FULL_PC).getOrElse(false))  Some(Vec(coreWidth*2, new GetPCSlice())) else None
+    val get_pc_slice = if (boomParams.loadSliceCore.map(_.ibdaTagType == IBDA_TAG_FULL_PC).getOrElse(false))  Some(Vec(coreWidth*2, new GetPCSlice())) else None
 
     // Restore predictor history on a branch mispredict or pipeline flush.
     val restore_history = Valid(new RestoreHistory)
@@ -305,7 +305,7 @@ class FetchTargetQueue(num_entries: Int)(implicit p: Parameters) extends BoomMod
   io.get_ftq_pc.next_pc := ram(WrapInc(curr_idx, num_entries)).fetch_pc
   io.get_ftq_pc.next_val := WrapInc(curr_idx, num_entries) =/= enq_ptr.value
 
-  if (boomParams.loadSliceCore.map(_.ibdaTag == IBDA_TAG_FULL_PC).getOrElse(false)) {
+  if (boomParams.loadSliceCore.map(_.ibdaTagType == IBDA_TAG_FULL_PC).getOrElse(false)) {
     val get_pc_slice = io.get_pc_slice.get
     for (w <- 0 until coreWidth*2) {
       get_pc_slice(w).fetch_pc := ram(get_pc_slice(w).ftq_idx).fetch_pc

--- a/src/main/scala/ifu/fetch-target-queue.scala
+++ b/src/main/scala/ifu/fetch-target-queue.scala
@@ -109,7 +109,7 @@ class FetchTargetQueue(num_entries: Int)(implicit p: Parameters) extends BoomMod
 
     // Give PC info to BranchUnit.
     val get_ftq_pc = new GetPCFromFtqIO()
-    val get_pc_slice = if (boomParams.loadSliceMode) Some(Vec(coreWidth*2, new GetPCSlice())) else None
+    val get_pc_slice = if (boomParams.loadSliceCore.map(_.ibdaTag == IBDA_TAG_FULL_PC).getOrElse(false))  Some(Vec(coreWidth*2, new GetPCSlice())) else None
 
     // Restore predictor history on a branch mispredict or pipeline flush.
     val restore_history = Valid(new RestoreHistory)
@@ -305,7 +305,7 @@ class FetchTargetQueue(num_entries: Int)(implicit p: Parameters) extends BoomMod
   io.get_ftq_pc.next_pc := ram(WrapInc(curr_idx, num_entries)).fetch_pc
   io.get_ftq_pc.next_val := WrapInc(curr_idx, num_entries) =/= enq_ptr.value
 
-  if (boomParams.loadSliceMode) {
+  if (boomParams.loadSliceCore.map(_.ibdaTag == IBDA_TAG_FULL_PC).getOrElse(false)) {
     val get_pc_slice = io.get_pc_slice.get
     for (w <- 0 until coreWidth*2) {
       get_pc_slice(w).fetch_pc := ram(get_pc_slice(w).ftq_idx).fetch_pc

--- a/src/main/scala/ifu/frontend.scala
+++ b/src/main/scala/ifu/frontend.scala
@@ -88,7 +88,7 @@ class BoomFrontendIO(implicit p: Parameters) extends BoomBundle
 
   val br_unit           = Output(new BranchUnitResp())
   val get_pc            = Flipped(new GetPCFromFtqIO())
-  val get_pc_slice      = if (boomParams.loadSliceCore.map(_.ibdaTag == IBDA_TAG_FULL_PC).getOrElse(false)) Some(Vec(coreWidth*2, Flipped(new GetPCSlice()))) else None
+  val get_pc_slice      = if (boomParams.loadSliceCore.map(_.ibdaTagType == IBDA_TAG_FULL_PC).getOrElse(false)) Some(Vec(coreWidth*2, Flipped(new GetPCSlice()))) else None
 
   val sfence            = Valid(new SFenceReq)
 

--- a/src/main/scala/ifu/frontend.scala
+++ b/src/main/scala/ifu/frontend.scala
@@ -88,7 +88,7 @@ class BoomFrontendIO(implicit p: Parameters) extends BoomBundle
 
   val br_unit           = Output(new BranchUnitResp())
   val get_pc            = Flipped(new GetPCFromFtqIO())
-  val get_pc_slice      = if (boomParams.loadSliceMode) Some(Vec(coreWidth*2, Flipped(new GetPCSlice()))) else None
+  val get_pc_slice      = if (boomParams.loadSliceCore.map(_.ibdaTag == IBDA_TAG_FULL_PC).getOrElse(false)) Some(Vec(coreWidth*2, Flipped(new GetPCSlice()))) else None
 
   val sfence            = Valid(new SFenceReq)
 

--- a/src/main/scala/lsc/InstructionSliceTable.scala
+++ b/src/main/scala/lsc/InstructionSliceTable.scala
@@ -10,7 +10,7 @@ import freechips.rocketchip.config.Parameters
 
 class IstCheck (implicit p: Parameters) extends BoomBundle
 {
-  val tag = Input(ValidIO(UInt(boomParams.loadSliceCore.get.ibdaTagSz.W)))
+  val tag = Input(ValidIO(UInt(IbdaParams.ibda_tag_sz.W)))
   val in_ist = Output(Bool())
 }
 

--- a/src/main/scala/lsc/InstructionSliceTable.scala
+++ b/src/main/scala/lsc/InstructionSliceTable.scala
@@ -22,7 +22,7 @@ class IstIO(implicit p: Parameters) extends BoomBundle
 
 class IstMark(implicit p: Parameters) extends BoomBundle
 {
-  val mark = Vec(retireWidth*2, ValidIO(UInt(boomParams.loadSliceCore.get.ibdaTagSz.W)))
+  val mark = Vec(retireWidth*2, ValidIO(UInt(IbdaParams.ibda_tag_sz.W)))
 }
 
 class InstructionSliceTable(entries: Int=128, ways: Int=2)(implicit p: Parameters) extends BoomModule{
@@ -30,7 +30,7 @@ class InstructionSliceTable(entries: Int=128, ways: Int=2)(implicit p: Parameter
   require(isPow2(entries))
   require(isPow2(ways))
 
-  val tag_table = Reg(Vec(entries, UInt(boomParams.loadSliceCore.get.ibdaTagSz.W)))
+  val tag_table = Reg(Vec(entries, UInt(IbdaParams.ibda_tag_sz.W)))
   val tag_valids = RegInit(VecInit(Seq.fill(entries)(false.B)))
   val tag_lru = RegInit(VecInit(Seq.fill(entries/2)(false.B)))
 

--- a/src/main/scala/lsc/InstructionSliceTable.scala
+++ b/src/main/scala/lsc/InstructionSliceTable.scala
@@ -1,6 +1,7 @@
 package lsc
 
 import boom.common.{BoomBundle, BoomModule, MicroOp}
+import boom.common._
 import boom.exu.{BrResolutionInfo, BusyResp, CommitSignals}
 import chisel3._
 import chisel3.core.Bundle
@@ -9,7 +10,7 @@ import freechips.rocketchip.config.Parameters
 
 class IstCheck (implicit p: Parameters) extends BoomBundle
 {
-  val addr = Input(ValidIO(UInt(vaddrBitsExtended.W)))
+  val tag = Input(ValidIO(UInt(boomParams.loadSliceCore.get.ibdaTagSz.W)))
   val in_ist = Output(Bool())
 }
 
@@ -21,17 +22,19 @@ class IstIO(implicit p: Parameters) extends BoomBundle
 
 class IstMark(implicit p: Parameters) extends BoomBundle
 {
-  val mark = Vec(retireWidth*2, ValidIO(UInt(vaddrBitsExtended.W)))
+  val mark = Vec(retireWidth*2, ValidIO(UInt(boomParams.loadSliceCore.get.ibdaTagSz.W)))
 }
 
 class InstructionSliceTable(entries: Int=128, ways: Int=2)(implicit p: Parameters) extends BoomModule{
-  val io = IO(new IstIO())
+  val io = IO(new IstIO)
   require(isPow2(entries))
   require(isPow2(ways))
 
-  val tag_table = Reg(Vec(entries, UInt(vaddrBitsExtended.W)))
+  val tag_table = Reg(Vec(entries, UInt(boomParams.loadSliceCore.get.ibdaTagSz.W)))
   val tag_valids = RegInit(VecInit(Seq.fill(entries)(false.B)))
   val tag_lru = RegInit(VecInit(Seq.fill(entries/2)(false.B)))
+
+
 
   def index(i: UInt): UInt ={
     val indexBits = log2Up(entries/ways)
@@ -41,11 +44,11 @@ class InstructionSliceTable(entries: Int=128, ways: Int=2)(implicit p: Parameter
   require(ways == 2, "only one lru bit for now!")
   // check
   for(i <- 0 until coreWidth){
-    val pc = io.check(i).addr.bits
+    val pc = io.check(i).tag.bits
     val idx = index(pc)
     val is_match = WireInit(false.B)
     io.check(i).in_ist := is_match // true if pc in IST
-    when(io.check(i).addr.valid){
+    when(io.check(i).tag.valid){
       for(j <- 0 until ways){
         val tidx = (idx << log2Up(ways)).asUInt() + j.U
         when(tag_valids(tidx) && tag_table(tidx) === pc){

--- a/src/main/scala/lsc/RegisterDependencyTable.scala
+++ b/src/main/scala/lsc/RegisterDependencyTable.scala
@@ -15,7 +15,7 @@ import boom.common._
 class RdtCommitSignals(implicit p: Parameters) extends BoomBundle
 {
   val rob = new CommitSignals()
-  val pc  = Vec(retireWidth, UInt(vaddrBitsExtended.W))
+  val tag  = Vec(retireWidth, UInt(boomParams.loadSliceCore.get.ibdaTagSz.W))
 }
 
 class RdtIO(implicit p: Parameters) extends BoomBundle
@@ -24,10 +24,10 @@ class RdtIO(implicit p: Parameters) extends BoomBundle
   val mark = Output(new IstMark)
 }
 
-class RegisterDependencyTable()(implicit p: Parameters) extends BoomModule{
-  val io = IO(new RdtIO())
+class RegisterDependencyTable(implicit p: Parameters) extends BoomModule{
+  val io = IO(new RdtIO)
 
-  val rdt = Reg(Vec(32, UInt(vaddrBitsExtended.W))) //32 is hardcoded for now since logicalRegCount includes fpu regs
+  val rdt = Reg(Vec(32, UInt(boomParams.loadSliceCore.get.ibdaTagSz.W))) //32 is hardcoded for now since logicalRegCount includes fpu regs
   val commit_dst_valid = WireInit(VecInit(Seq.fill(retireWidth)(false.B)))
 
   io.mark := DontCare
@@ -39,7 +39,7 @@ class RegisterDependencyTable()(implicit p: Parameters) extends BoomModule{
     // exclude 0 reg
     when(io.commit.rob.valids(i) && uop.dst_rtype === RT_FIX && uop.ldst =/= 0.U){
       // TODO: figure out if there is a better pc - guess we shouldn't use debug...
-      rdt(uop.ldst) := io.commit.pc(i)
+      rdt(uop.ldst) := io.commit.tag(i)
       commit_dst_valid(i) := true.B
     }
 
@@ -53,7 +53,7 @@ class RegisterDependencyTable()(implicit p: Parameters) extends BoomModule{
         for (j <- 0 until i){
           val uop_j = io.commit.rob.uops(j)
           when(commit_dst_valid(j) && uop_j.ldst === uop.lrs1){
-            io.mark.mark(2*i).bits := io.commit.pc(j)
+            io.mark.mark(2*i).bits := io.commit.tag(j)
           }
         }
       }
@@ -64,7 +64,7 @@ class RegisterDependencyTable()(implicit p: Parameters) extends BoomModule{
         for (j <- 0 until i){
           val uop_j = io.commit.rob.uops(j)
           when(commit_dst_valid(j) && uop_j.ldst === uop.lrs2){
-            io.mark.mark(2*i).bits := io.commit.pc(j)
+            io.mark.mark(2*i).bits := io.commit.tag(j)
           }
         }
       }

--- a/src/main/scala/lsc/RegisterDependencyTable.scala
+++ b/src/main/scala/lsc/RegisterDependencyTable.scala
@@ -8,14 +8,14 @@ import boom.common._
 
 /**
   * Custom commit signals combining ROBs commit signals
-  * with a PC that must be fetched from the FTQ
-  * @param p
+  * with a tag that could arrive from somewhere else (like the FTQ)
+  * @param
   */
 
 class RdtCommitSignals(implicit p: Parameters) extends BoomBundle
 {
   val rob = new CommitSignals()
-  val tag  = Vec(retireWidth, UInt(boomParams.loadSliceCore.get.ibdaTagSz.W))
+  val tag  = Vec(retireWidth, UInt(IbdaParams.ibda_tag_sz.W))
 }
 
 class RdtIO(implicit p: Parameters) extends BoomBundle
@@ -27,7 +27,7 @@ class RdtIO(implicit p: Parameters) extends BoomBundle
 class RegisterDependencyTable(implicit p: Parameters) extends BoomModule{
   val io = IO(new RdtIO)
 
-  val rdt = Reg(Vec(32, UInt(boomParams.loadSliceCore.get.ibdaTagSz.W))) //32 is hardcoded for now since logicalRegCount includes fpu regs
+  val rdt = Reg(Vec(32, UInt(IbdaParams.ibda_tag_sz.W))) //32 is hardcoded for now since logicalRegCount includes fpu regs
   val commit_dst_valid = WireInit(VecInit(Seq.fill(retireWidth)(false.B)))
 
   io.mark := DontCare
@@ -38,7 +38,6 @@ class RegisterDependencyTable(implicit p: Parameters) extends BoomModule{
     // record pc of last insn that committed to reg
     // exclude 0 reg
     when(io.commit.rob.valids(i) && uop.dst_rtype === RT_FIX && uop.ldst =/= 0.U){
-      // TODO: figure out if there is a better pc - guess we shouldn't use debug...
       rdt(uop.ldst) := io.commit.tag(i)
       commit_dst_valid(i) := true.B
     }

--- a/src/main/scala/lsc/ibda.scala
+++ b/src/main/scala/lsc/ibda.scala
@@ -12,6 +12,8 @@ object IbdaParams extends LoadSliceCoreParams {
     if(ibdaTagType == IBDA_TAG_FULL_PC) tag := uop.debug_pc
     else if (ibdaTagType == IBDA_TAG_UOPC_LOB) tag := Cat(uop.uopc, uop.pc_lob)
     else if (ibdaTagType == IBDA_TAG_INST_LOB) tag := Cat(uop.inst, uop.pc_lob)
+    else assert(false.B, "ibda_get_tag not implemented for this tag")
+
     tag
   }
 
@@ -21,6 +23,10 @@ object IbdaParams extends LoadSliceCoreParams {
       case IBDA_TAG_FULL_PC => 40
       case IBDA_TAG_UOPC_LOB => UOPC_SZ + 6 //uopc + pc_lob
       case IBDA_TAG_INST_LOB => 32 + 6 //inst + pc_lob
+      case _ => {
+        assert(false.B, "ibda_tag_sz not implemented for this tag")
+        0
+      }
     }
 
   }

--- a/src/main/scala/lsc/ibda.scala
+++ b/src/main/scala/lsc/ibda.scala
@@ -1,0 +1,18 @@
+package lsc
+import boom.common._
+import chisel3._
+import chisel3.core.Bundle
+import chisel3.util._
+import freechips.rocketchip.config.Parameters
+
+object IbdaParams extends LoadSliceCoreParams {
+  // Get tag is a function that calculates the tag from a MicroOp
+  def ibda_get_tag(uop: MicroOp): UInt = {
+    val tag = Wire(UInt(ibdaTagSz.W))
+    if(ibdaTagType == IBDA_TAG_FULL_PC) tag := uop.debug_pc
+    else if (ibdaTagType == IBDA_TAG_UOPC_LOB) tag := Cat(uop.uopc, uop.pc_lob)
+    else if (ibdaTagType == IBDA_TAG_INST_LOB) tag := Cat(uop.inst, uop.pc_lob)
+    tag
+  }
+
+}

--- a/src/main/scala/lsc/ibda.scala
+++ b/src/main/scala/lsc/ibda.scala
@@ -8,11 +8,21 @@ import freechips.rocketchip.config.Parameters
 object IbdaParams extends LoadSliceCoreParams {
   // Get tag is a function that calculates the tag from a MicroOp
   def ibda_get_tag(uop: MicroOp): UInt = {
-    val tag = Wire(UInt(ibdaTagSz.W))
+    val tag = Wire(UInt(ibda_tag_sz.W))
     if(ibdaTagType == IBDA_TAG_FULL_PC) tag := uop.debug_pc
     else if (ibdaTagType == IBDA_TAG_UOPC_LOB) tag := Cat(uop.uopc, uop.pc_lob)
     else if (ibdaTagType == IBDA_TAG_INST_LOB) tag := Cat(uop.inst, uop.pc_lob)
     tag
+  }
+
+  // Get tag size.
+  def ibda_tag_sz() : Int = {
+    ibdaTagType match {
+      case IBDA_TAG_FULL_PC => 40
+      case IBDA_TAG_UOPC_LOB => UOPC_SZ + 6 //uopc + pc_lob
+      case IBDA_TAG_INST_LOB => 32 + 6 //inst + pc_lob
+    }
+
   }
 
 }


### PR DESCRIPTION

**Release Notes**
- Introduce config parameter for IBDA tag type (e.g. full PC, inst+lob, uopc+lob). Specified in config-mixin
- new functions get_tag and tag_sz in new file ibda.scala. For each new tag type we add, we must update these functions for the size and the "hashing" of the tag from a MicroOp
- Only make new PC ports to FTQ if tag type is FULL_PC