### PR TITLE
Lsc move rdt

### DIFF
--- a/src/main/scala/common/consts.scala
+++ b/src/main/scala/common/consts.scala
@@ -411,9 +411,6 @@ trait LoadSliceCoreConstants
   val LSC_DIS_A_PORT_IDX = 0
   val LSC_DIS_B_PORT_IDX = 1
 
-  val IstFtqPortIdx = 0
-  val RdtFtqPortIdx = 2
-
   val IBDA_TAG_FULL_PC = 0
   val IBDA_TAG_UOPC_LOB = 1
   val IBDA_TAG_INST_LOB = 2

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -487,25 +487,24 @@ class BoomCore(implicit p: Parameters) extends BoomModule
 
   //-------------------------------------------------------------
   // Instruction Slice Lookup
-  val ist_pc = Option(Wire(Vec(decodeWidth, UInt(vaddrBitsExtended.W))))
+  val ist_pc =  WireInit(VecInit(Seq.fill(decodeWidth) {0.U(vaddrBitsExtended.W)}))
   if (boomParams.loadSliceMode) {
     // If we want the Full PC we need FTQ ports and etc. This is not
     //  the preferred way since we need so many ports to FTQ
     if (boomParams.loadSliceCore.get.ibdaTagType == IBDA_TAG_FULL_PC) {
       val get_pc_slice = io.ifu.get_pc_slice.get
       for (w <- 0 until coreWidth) {
-        // Access only IST ports
-        val idx = w + IstFtqPortIdx
+
         // Request fetch_pc from FTQ
-        get_pc_slice(idx).ftq_idx := dec_uops(w).ftq_idx
+        get_pc_slice(w).ftq_idx := dec_uops(w).ftq_idx
         // Recreate PC for dispatched uop
-        val block_pc = AlignPCToBoundary(get_pc_slice(idx).fetch_pc, icBlockBytes)
-        ist_pc.get(w) := (block_pc | dec_uops(w).pc_lob) - Mux(dec_uops(w).edge_inst, 2.U, 0.U)
+        val block_pc = AlignPCToBoundary(get_pc_slice(w).fetch_pc, icBlockBytes)
+        ist_pc(w) := (block_pc | dec_uops(w).pc_lob) - Mux(dec_uops(w).edge_inst, 2.U, 0.U)
         ist.get.io.check(w).tag.valid := dec_fire(w)
-        ist.get.io.check(w).tag.bits := ist_pc.get(w)
+        ist.get.io.check(w).tag.bits := ist_pc(w)
         dis_uops(w).is_lsc_b := ist.get.io.check(w).in_ist
 
-        assert(!(dec_fire(w) && (dec_uops(w).debug_pc =/= ist_pc.get(w))), "[IST] debug_pc and fetch_pc mismatch")
+        assert(!(dec_fire(w) && (dec_uops(w).debug_pc =/= ist_pc(w))), "[IST] debug_pc and fetch_pc mismatch")
       }
     } else {
       // We dont want the full PC but rather some hash of the UOP.
@@ -589,10 +588,10 @@ class BoomCore(implicit p: Parameters) extends BoomModule
     for (w <- 0 until decodeWidth) {
       rdt.get.io.update(w).valid := dis_fire(w)
       rdt.get.io.update(w).uop := dis_uops(w)
-      rdt.get.io.update(w).tag :=  if (boomParams.loadSliceCore.get.ibdaTagType == IBDA_TAG_FULL_PC) {
-         RegNext(ist_pc.get(w))
+      if (boomParams.loadSliceCore.get.ibdaTagType == IBDA_TAG_FULL_PC) {
+        rdt.get.io.update(w).tag :=  RegNext(ist_pc(w))
       } else {
-          IbdaParams.ibda_get_tag(dis_uops(w))
+        rdt.get.io.update(w).tag :=  IbdaParams.ibda_get_tag(dis_uops(w))
       }
 
     }

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -484,6 +484,39 @@ class BoomCore(implicit p: Parameters) extends BoomModule
 
   branch_mask_full := dec_brmask_logic.io.is_full
 
+
+  //-------------------------------------------------------------
+  // Instruction Slice Lookup
+  val ist_pc = Option(Wire(Vec(decodeWidth, UInt(vaddrBitsExtended.W))))
+  if (boomParams.loadSliceMode) {
+    // If we want the Full PC we need FTQ ports and etc. This is not
+    //  the preferred way since we need so many ports to FTQ
+    if (boomParams.loadSliceCore.get.ibdaTagType == IBDA_TAG_FULL_PC) {
+      val get_pc_slice = io.ifu.get_pc_slice.get
+      for (w <- 0 until coreWidth) {
+        // Access only IST ports
+        val idx = w + IstFtqPortIdx
+        // Request fetch_pc from FTQ
+        get_pc_slice(idx).ftq_idx := dec_uops(w).ftq_idx
+        // Recreate PC for dispatched uop
+        val block_pc = AlignPCToBoundary(get_pc_slice(idx).fetch_pc, icBlockBytes)
+        ist_pc.get(w) := (block_pc | dec_uops(w).pc_lob) - Mux(dec_uops(w).edge_inst, 2.U, 0.U)
+        ist.get.io.check(w).tag.valid := dec_fire(w)
+        ist.get.io.check(w).tag.bits := ist_pc.get(w)
+        dis_uops(w).is_lsc_b := ist.get.io.check(w).in_ist
+
+        assert(!(dec_fire(w) && (dec_uops(w).debug_pc =/= ist_pc.get(w))), "[IST] debug_pc and fetch_pc mismatch")
+      }
+    } else {
+      // We dont want the full PC but rather some hash of the UOP.
+      for (w <- 0 until coreWidth) {
+        ist.get.io.check(w).tag.valid := dec_fire(w)
+        ist.get.io.check(w).tag.bits := IbdaParams.ibda_get_tag(dec_uops(w))
+      }
+    }
+  }
+
+
   //-------------------------------------------------------------
   //-------------------------------------------------------------
   // **** Register Rename Stage ****
@@ -541,6 +574,31 @@ class BoomCore(implicit p: Parameters) extends BoomModule
 
     ren_stalls(w) := rename_stage.io.ren_stalls(w) || f_stall
   }
+
+
+  //-------------------------------------------------------------
+  // Register Dependency Table update
+  //-------------------------------------------------------------
+
+  if (boomParams.loadSliceMode) {
+    // Connect RDT to IST. Mark new instructions as part of a load slice in IST
+    ist.get.io.mark := rdt.get.io.mark
+
+    // Connect the dispatched instruction to RDT. If we wanna use the full pc also
+    //  get the PC that the IST calculated last CC
+    for (w <- 0 until decodeWidth) {
+      rdt.get.io.update(w).valid := dis_fire(w)
+      rdt.get.io.update(w).uop := dis_uops(w)
+      rdt.get.io.update(w).tag :=  if (boomParams.loadSliceCore.get.ibdaTagType == IBDA_TAG_FULL_PC) {
+         RegNext(ist_pc.get(w))
+      } else {
+          IbdaParams.ibda_get_tag(dis_uops(w))
+      }
+
+    }
+
+  }
+
 
   //-------------------------------------------------------------
   //-------------------------------------------------------------
@@ -624,43 +682,6 @@ class BoomCore(implicit p: Parameters) extends BoomModule
 
   //-------------------------------------------------------------
   // Dispatch to issue queues
-
-  /**
-    * IBDA stuff
-    *
-    */
-
-  // Calculate the size of the tag based on the config chosen in config-mixin.scala
-  if (boomParams.loadSliceMode) {
-
-    // If we want the Full PC we need FTQ ports and etc. This is not
-    //  the preferred way since we need so many ports to FTQ
-    if (boomParams.loadSliceCore.get.ibdaTagType == IBDA_TAG_FULL_PC) {
-      val get_pc_slice = io.ifu.get_pc_slice.get
-      for (w <- 0 until coreWidth) {
-        // Access only IST ports
-        val idx = w + IstFtqPortIdx
-        // Request fetch_pc from FTQ
-        get_pc_slice(idx).ftq_idx := dis_uops(w).ftq_idx
-        // Recreate PC for dispatched uop
-        val block_pc = AlignPCToBoundary(get_pc_slice(idx).fetch_pc, icBlockBytes)
-        val pc = (block_pc | dis_uops(w).pc_lob) - Mux(dis_uops(w).edge_inst, 2.U, 0.U)
-        ist.get.io.check(w).tag.valid := dis_fire(w)
-        ist.get.io.check(w).tag.bits := pc
-        dis_uops(w).is_lsc_b := ist.get.io.check(w).in_ist
-
-        assert(!(dis_fire(w) && (dis_uops(w).debug_pc =/= pc)), "[IST] debug_pc and fetch_pc mismatch")
-      }
-    } else {
-      // We dont want the full PC but rather some hash of the UOP.
-      //  The hash itself is chosen in the ibda_get_tag function defined above
-      for (w <- 0 until coreWidth) {
-        ist.get.io.check(w).tag.valid := dis_fire(w)
-        ist.get.io.check(w).tag.bits := IbdaParams.ibda_get_tag(dis_uops(w))
-      }
-    }
-
-  }
 
   // Get uops from rename2
   for (w <- 0 until coreWidth) {
@@ -1160,40 +1181,6 @@ class BoomCore(implicit p: Parameters) extends BoomModule
   assert (!(csr.io.singleStep), "[core] single-step is unsupported.")
 
   rob.io.bxcpt <> br_unit.xcpt
-
-  //-------------------------------------------------------------
-  // **** IBDA ****
-  //-------------------------------------------------------------
-
-  if (boomParams.loadSliceMode) {
-    // Connect RDT and IST and forward the commit signals from ROB to RDT
-
-    ist.get.io.mark := rdt.get.io.mark
-    rdt.get.io.commit.rob := rob.io.commit
-
-    if (boomParams.loadSliceCore.get.ibdaTagType == IBDA_TAG_FULL_PC) {
-      // Unwrap port to FTQ
-      val get_pc_slice = io.ifu.get_pc_slice.get
-      for (w <- 0 until retireWidth) {
-        val idx = w + RdtFtqPortIdx
-        // Request fetch_pc from ftq_idx
-        get_pc_slice(idx).ftq_idx := rob.io.commit.uops(w).ftq_idx
-        // Recreate PC of this instruction
-        val block_pc = AlignPCToBoundary(get_pc_slice(idx).fetch_pc, icBlockBytes)
-        val pc = (block_pc | rob.io.commit.uops(w).pc_lob) - Mux(rob.io.commit.uops(w).edge_inst, 2.U, 0.U)
-        rdt.get.io.commit.tag(w) := pc
-
-        assert(!(rob.io.commit.valids(w) && (pc =/= rob.io.commit.uops(w).debug_pc)), "[RDT] fetch_pc and debug_pc mismatch")
-      }
-    } else {
-      for (w <- 0 until retireWidth) {
-        rdt.get.io.commit.tag(w) := IbdaParams.ibda_get_tag(rob.io.commit.uops(w))
-      }
-    }
-
-  }
-
-
 
   //-------------------------------------------------------------
   // **** Flush Pipeline ****

--- a/src/main/scala/ifu/fetch-control-unit.scala
+++ b/src/main/scala/ifu/fetch-control-unit.scala
@@ -92,7 +92,7 @@ class FetchControlUnit(implicit p: Parameters) extends BoomModule
 
     val br_unit           = Input(new BranchUnitResp())
     val get_pc            = new GetPCFromFtqIO()
-    val get_pc_slice      = if(boomParams.loadSliceCore.map(_.ibdaTagType == IBDA_TAG_FULL_PC).getOrElse(false)) Some(Vec(coreWidth*2, new GetPCSlice())) else None
+    val get_pc_slice      = if(boomParams.loadSliceCore.map(_.ibdaTagType == IBDA_TAG_FULL_PC).getOrElse(false)) Some(Vec(coreWidth, new GetPCSlice())) else None
 
     // Breakpoint info
     val status            = Input(new MStatus)

--- a/src/main/scala/ifu/fetch-target-queue.scala
+++ b/src/main/scala/ifu/fetch-target-queue.scala
@@ -109,7 +109,7 @@ class FetchTargetQueue(num_entries: Int)(implicit p: Parameters) extends BoomMod
 
     // Give PC info to BranchUnit.
     val get_ftq_pc = new GetPCFromFtqIO()
-    val get_pc_slice = if (boomParams.loadSliceCore.map(_.ibdaTagType == IBDA_TAG_FULL_PC).getOrElse(false))  Some(Vec(coreWidth*2, new GetPCSlice())) else None
+    val get_pc_slice = if (boomParams.loadSliceCore.map(_.ibdaTagType == IBDA_TAG_FULL_PC).getOrElse(false))  Some(Vec(coreWidth, new GetPCSlice())) else None
 
     // Restore predictor history on a branch mispredict or pipeline flush.
     val restore_history = Valid(new RestoreHistory)
@@ -307,7 +307,7 @@ class FetchTargetQueue(num_entries: Int)(implicit p: Parameters) extends BoomMod
 
   if (boomParams.loadSliceCore.map(_.ibdaTagType == IBDA_TAG_FULL_PC).getOrElse(false)) {
     val get_pc_slice = io.get_pc_slice.get
-    for (w <- 0 until coreWidth*2) {
+    for (w <- 0 until coreWidth) {
       get_pc_slice(w).fetch_pc := ram(get_pc_slice(w).ftq_idx).fetch_pc
     }
   }

--- a/src/main/scala/ifu/frontend.scala
+++ b/src/main/scala/ifu/frontend.scala
@@ -88,7 +88,7 @@ class BoomFrontendIO(implicit p: Parameters) extends BoomBundle
 
   val br_unit           = Output(new BranchUnitResp())
   val get_pc            = Flipped(new GetPCFromFtqIO())
-  val get_pc_slice      = if (boomParams.loadSliceCore.map(_.ibdaTagType == IBDA_TAG_FULL_PC).getOrElse(false)) Some(Vec(coreWidth*2, Flipped(new GetPCSlice()))) else None
+  val get_pc_slice      = if (boomParams.loadSliceCore.map(_.ibdaTagType == IBDA_TAG_FULL_PC).getOrElse(false)) Some(Vec(coreWidth, Flipped(new GetPCSlice()))) else None
 
   val sfence            = Valid(new SFenceReq)
 

--- a/src/main/scala/lsc/RegisterDependencyTable.scala
+++ b/src/main/scala/lsc/RegisterDependencyTable.scala
@@ -12,58 +12,63 @@ import boom.common._
   * @param
   */
 
-class RdtCommitSignals(implicit p: Parameters) extends BoomBundle
+class RdtUpdateSignals(implicit p: Parameters) extends BoomBundle
 {
-  val rob = new CommitSignals()
-  val tag  = Vec(retireWidth, UInt(IbdaParams.ibda_tag_sz.W))
+  val valid = Bool()
+  val tag  = UInt(IbdaParams.ibda_tag_sz.W)
+  val uop = new MicroOp
 }
 
 class RdtIO(implicit p: Parameters) extends BoomBundle
 {
-  val commit = Input(new RdtCommitSignals)
+  val update = Input(Vec(decodeWidth, new RdtUpdateSignals))
   val mark = Output(new IstMark)
 }
 
 class RegisterDependencyTable(implicit p: Parameters) extends BoomModule{
   val io = IO(new RdtIO)
 
-  val rdt = Reg(Vec(32, UInt(IbdaParams.ibda_tag_sz.W))) //32 is hardcoded for now since logicalRegCount includes fpu regs
-  val commit_dst_valid = WireInit(VecInit(Seq.fill(retireWidth)(false.B)))
+  val rdt = Reg(Vec(boomParams.numIntPhysRegisters, UInt(IbdaParams.ibda_tag_sz.W)))
+  val commit_dst_valid = WireInit(VecInit(Seq.fill(decodeWidth)(false.B)))
 
   io.mark := DontCare
   io.mark.mark.map(_.valid := false.B)
 
-  for(i <- 0 until retireWidth){
-    val uop = io.commit.rob.uops(i)
+  for(i <- 0 until decodeWidth){
+
+
+    val uop = io.update(i).uop
+    val valid = io.update(i).valid
+    val tag = io.update(i).tag
+
     // record pc of last insn that committed to reg
-    // exclude 0 reg
-    when(io.commit.rob.valids(i) && uop.dst_rtype === RT_FIX && uop.ldst =/= 0.U){
-      rdt(uop.ldst) := io.commit.tag(i)
+    when(valid && uop.dst_rtype === RT_FIX && uop.ldst =/= 0.U){
+      rdt(uop.ldst) := tag
       commit_dst_valid(i) := true.B
     }
 
     val is_b = uop.is_lsc_b || uop.uopc === uopLD || uop.uopc === uopSTA || uop.uopc === uopSTD
     // add pcs of dependent insns to ist
-    when(io.commit.rob.valids(i) && is_b){
+    when(valid && is_b){
       when(uop.lrs1_rtype === RT_FIX && uop.lrs1 =/= 0.U){
         io.mark.mark(2*i).valid := true.B
-        io.mark.mark(2*i).bits := rdt(uop.lrs1)
+        io.mark.mark(2*i).bits := rdt(uop.prs1)
         // bypass rdt for previous insns committed in same cycle
         for (j <- 0 until i){
-          val uop_j = io.commit.rob.uops(j)
-          when(commit_dst_valid(j) && uop_j.ldst === uop.lrs1){
-            io.mark.mark(2*i).bits := io.commit.tag(j)
+          val uop_j = io.update(j).uop
+          when(commit_dst_valid(j) && uop_j.ldst === uop.prs1){
+            io.mark.mark(2*i).bits := io.update(i).tag
           }
         }
       }
       when(uop.lrs2_rtype === RT_FIX && uop.lrs2 =/= 0.U){
         io.mark.mark(2*i+1).valid := true.B
-        io.mark.mark(2*i+1).bits := rdt(uop.lrs2)
+        io.mark.mark(2*i+1).bits := rdt(uop.prs2)
         // bypass rdt for previous insns committed in same cycle
         for (j <- 0 until i){
-          val uop_j = io.commit.rob.uops(j)
-          when(commit_dst_valid(j) && uop_j.ldst === uop.lrs2){
-            io.mark.mark(2*i).bits := io.commit.tag(j)
+          val uop_j = io.update(j).uop
+          when(commit_dst_valid(j) && uop_j.ldst === uop.prs2){
+            io.mark.mark(2*i).bits := io.update(j).tag
           }
         }
       }


### PR DESCRIPTION
solves #16

- Move IST lookup in parallel with Decode
- Change RDT Commit => RDT Update
- Move RDT Update to ren2/dispatch
- For tag=ful_pc: Use decodeWIdth extra ports to FTQ. Only for IST. Delay the PCs for 1CC such that RDT can use them also
