### PR TITLE
Lsc rdt in ist

### DIFF
--- a/src/main/scala/common/config-mixins.scala
+++ b/src/main/scala/common/config-mixins.scala
@@ -219,7 +219,7 @@ class WithSliceBooms extends Config((site, here, up) => {
       fpu = Some(freechips.rocketchip.tile.FPUParams(sfmaLatency=4, dfmaLatency=4, divSqrt=true)),
       useAtomics = true,
       usingFPU = true,
-      loadSliceCore = Some(LoadSliceCoreParams(numAqEntries = 8, numBqEntries = 8, ibdaTagType = IBDA_TAG_FULL_PC))
+      loadSliceCore = Some(LoadSliceCoreParams(numAqEntries = 8, numBqEntries = 8, ibdaTagType = IBDA_TAG_FULL_PC, rdtIstMarkWidth = 1))
     ),
     dcache = Some(DCacheParams(rowBits = site(SystemBusKey).beatBits,
                                nSets=64, nWays=4, nMSHRs=2, nTLBEntries=8)),

--- a/src/main/scala/common/config-mixins.scala
+++ b/src/main/scala/common/config-mixins.scala
@@ -219,7 +219,7 @@ class WithSliceBooms extends Config((site, here, up) => {
       fpu = Some(freechips.rocketchip.tile.FPUParams(sfmaLatency=4, dfmaLatency=4, divSqrt=true)),
       useAtomics = true,
       usingFPU = true,
-      loadSliceCore = Some(LoadSliceCoreParams(numAqEntries = 8, numBqEntries = 8, ibdaTagType = IBDA_TAG_INST_LOB))
+      loadSliceCore = Some(LoadSliceCoreParams(numAqEntries = 8, numBqEntries = 8, ibdaTagType = IBDA_TAG_FULL_PC))
     ),
     dcache = Some(DCacheParams(rowBits = site(SystemBusKey).beatBits,
                                nSets=64, nWays=4, nMSHRs=2, nTLBEntries=8)),

--- a/src/main/scala/common/config-mixins.scala
+++ b/src/main/scala/common/config-mixins.scala
@@ -219,7 +219,7 @@ class WithSliceBooms extends Config((site, here, up) => {
       fpu = Some(freechips.rocketchip.tile.FPUParams(sfmaLatency=4, dfmaLatency=4, divSqrt=true)),
       useAtomics = true,
       usingFPU = true,
-      loadSliceCore = Some(LoadSliceCoreParams(numAqEntries = 8, numBqEntries = 8, ibdaTagType = IBDA_TAG_FULL_PC))
+      loadSliceCore = Some(LoadSliceCoreParams(numAqEntries = 8, numBqEntries = 8, ibdaTagType = IBDA_TAG_INST_LOB))
     ),
     dcache = Some(DCacheParams(rowBits = site(SystemBusKey).beatBits,
                                nSets=64, nWays=4, nMSHRs=2, nTLBEntries=8)),

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -307,7 +307,8 @@ case class DromajoParams(
 case class LoadSliceCoreParams(
   numAqEntries: Int = 8,
   numBqEntries: Int = 8,
-  ibdaTagType: Int = IBDA_TAG_FULL_PC
+  ibdaTagType: Int = IBDA_TAG_FULL_PC,
+  rdtIstMarkWidth: Int = 1
                               ) {
 
   def ibda_get_tag(uop: MicroOp): UInt = {

--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -308,7 +308,7 @@ case class LoadSliceCoreParams(
   numAqEntries: Int = 8,
   numBqEntries: Int = 8,
   ibdaTagType: Int = IBDA_TAG_FULL_PC,
-  rdtIstMarkWidth: Int = 1
+  rdtIstMarkWidth: Int = 4
                               ) {
 
   def ibda_get_tag(uop: MicroOp): UInt = {

--- a/src/main/scala/exu/core.scala
+++ b/src/main/scala/exu/core.scala
@@ -43,7 +43,7 @@ import boom.common._
 import boom.exu.FUConstants._
 import boom.common.BoomTilesKey
 import boom.util.{RobTypeToChars, BoolToChar, GetNewUopAndBrMask, Sext, WrapInc, BoomCoreStringPrefix, DromajoCosimBlackBox, AlignPCToBoundary}
-import lsc.{InstructionSliceTable, RegisterDependencyTable}
+import lsc.{InstructionSliceTable, RdtOneBit, RdtBasic}
 
 
 /**
@@ -142,7 +142,7 @@ class BoomCore(implicit p: Parameters) extends BoomModule
                            numFpWakeupPorts))
 
   val ist = if(boomParams.loadSliceMode) Some(Module(new InstructionSliceTable())) else None
-  val rdt = if(boomParams.loadSliceMode) Some(Module(new RegisterDependencyTable())) else None
+  val rdt = if(boomParams.loadSliceMode) Some(Module(new RdtOneBit())) else None
   // Used to wakeup registers in rename and issue. ROB needs to listen to something else.
   val int_iss_wakeups  = Wire(Vec(numIntIssueWakeupPorts, Valid(new ExeUnitResp(xLen))))
   val int_ren_wakeups  = Wire(Vec(numIntRenameWakeupPorts, Valid(new ExeUnitResp(xLen))))

--- a/src/main/scala/lsc/InstructionSliceTable.scala
+++ b/src/main/scala/lsc/InstructionSliceTable.scala
@@ -16,7 +16,7 @@ class IstCheck (implicit p: Parameters) extends BoomBundle
 
 class IstIO(implicit p: Parameters) extends BoomBundle
 {
-  val mark = Vec(retireWidth*2, Input(new IstMark))
+  val mark = Vec(boomParams.loadSliceCore.get.rdtIstMarkWidth, Input(new IstMark))
   val check = Vec(coreWidth, new IstCheck)
 }
 
@@ -73,7 +73,7 @@ class InstructionSliceTable(entries: Int=128, ways: Int=2)(implicit p: Parameter
     }
   }
   // mark - later so mark lrus get priority
-  for(i <- 0 until retireWidth*2){
+  for(i <- 0 until lscParams.rdtIstMarkWidth){
     when(io.mark(i).mark.valid){
       val pc = io.mark(i).mark.bits
       val idx = index(pc)

--- a/src/main/scala/lsc/InstructionSliceTable.scala
+++ b/src/main/scala/lsc/InstructionSliceTable.scala
@@ -36,6 +36,8 @@ class InstructionSliceTable(entries: Int=128, ways: Int=2)(implicit p: Parameter
 
   val lscParams = boomParams.loadSliceCore.get
 
+  require(entries == 128)
+  require(ways == 2)
   def index(i: UInt): UInt = {
 
     val indexBits = log2Up(entries/ways)
@@ -44,7 +46,8 @@ class InstructionSliceTable(entries: Int=128, ways: Int=2)(implicit p: Parameter
       // xor the second lowest bit with the highest index bit so compressed insns are spread around
       index := i(indexBits+2-1, 2) ^ Cat(i(1), 0.U((indexBits-1).W))
     } else if (lscParams.ibdaTagType == IBDA_TAG_INST_LOB) {
-      index := i(indexBits+2-1,2) ^ Cat(i(1), 0.U((indexBits-1).W))
+      index := Cat(i(12), i(13), i(5,2)) ^ Cat(i(1), 0.U((indexBits-1).W))
+      // TODO: Research the entropy in the instruction encoding?
     } else if (lscParams.ibdaTagType == IBDA_TAG_UOPC_LOB) {
       index := i(indexBits+2-1,2) ^ Cat(i(1), 0.U((indexBits-1).W))
     }

--- a/src/main/scala/lsc/InstructionSliceTable.scala
+++ b/src/main/scala/lsc/InstructionSliceTable.scala
@@ -34,12 +34,23 @@ class InstructionSliceTable(entries: Int=128, ways: Int=2)(implicit p: Parameter
   val tag_valids = RegInit(VecInit(Seq.fill(entries)(false.B)))
   val tag_lru = RegInit(VecInit(Seq.fill(entries/2)(false.B)))
 
+  val lscParams = boomParams.loadSliceCore.get
 
+  def index(i: UInt): UInt = {
 
-  def index(i: UInt): UInt ={
     val indexBits = log2Up(entries/ways)
-    // xor the second lowest bit with the highest index bit so compressed insns are spread around
-    i(indexBits+2-1, 2) ^ Cat(i(1), 0.U((indexBits-1).W))
+    val index = Wire(UInt(indexBits.W))
+    if (lscParams.ibdaTagType == IBDA_TAG_FULL_PC) {
+      // xor the second lowest bit with the highest index bit so compressed insns are spread around
+      index := i(indexBits+2-1, 2) ^ Cat(i(1), 0.U((indexBits-1).W))
+    } else if (lscParams.ibdaTagType == IBDA_TAG_INST_LOB) {
+      index := i(indexBits+2-1,2) ^ Cat(i(1), 0.U((indexBits-1).W))
+    } else if (lscParams.ibdaTagType == IBDA_TAG_UOPC_LOB) {
+      index := i(indexBits+2-1,2) ^ Cat(i(1), 0.U((indexBits-1).W))
+    }
+
+    index
+
   }
   require(ways == 2, "only one lru bit for now!")
   // check

--- a/src/main/scala/lsc/InstructionSliceTable.scala
+++ b/src/main/scala/lsc/InstructionSliceTable.scala
@@ -16,13 +16,13 @@ class IstCheck (implicit p: Parameters) extends BoomBundle
 
 class IstIO(implicit p: Parameters) extends BoomBundle
 {
-  val mark = Input(new IstMark)
+  val mark = Vec(retireWidth*2, Input(new IstMark))
   val check = Vec(coreWidth, new IstCheck)
 }
 
 class IstMark(implicit p: Parameters) extends BoomBundle
 {
-  val mark = Vec(retireWidth*2, ValidIO(UInt(boomParams.loadSliceCore.get.ibda_tag_sz.W)))
+  val mark = ValidIO(UInt(boomParams.loadSliceCore.get.ibda_tag_sz.W))
 }
 
 class InstructionSliceTable(entries: Int=128, ways: Int=2)(implicit p: Parameters) extends BoomModule{
@@ -74,8 +74,8 @@ class InstructionSliceTable(entries: Int=128, ways: Int=2)(implicit p: Parameter
   }
   // mark - later so mark lrus get priority
   for(i <- 0 until retireWidth*2){
-    when(io.mark.mark(i).valid){
-      val pc = io.mark.mark(i).bits
+    when(io.mark(i).mark.valid){
+      val pc = io.mark(i).mark.bits
       val idx = index(pc)
       val is_match = WireInit(false.B)
       for(j <- 0 until ways){

--- a/src/main/scala/lsc/RegisterDependencyTable.scala
+++ b/src/main/scala/lsc/RegisterDependencyTable.scala
@@ -90,7 +90,6 @@ class RdtOneBit(implicit p: Parameters) extends RegisterDependencyTable {
           io.mark(port_idx).mark.valid := !in_ist(uop.prs1) // Only valid when RS1 is not already in IST
           port_used := !in_ist(uop.prs1)
           io.mark(port_idx).mark.bits := rdt(uop.prs1)
-          in_ist(uop.prs1) := true.B // Update in_ist
           // bypass rdt for previous insns written in same cycle
           for (j <- 0 until i) {
             val uop_j = io.update(j).uop
@@ -100,6 +99,9 @@ class RdtOneBit(implicit p: Parameters) extends RegisterDependencyTable {
               port_used := !uop_j_in_ist
               io.mark(port_idx).mark.bits := io.update(j).tag
             }
+          }
+          when (port_used) {
+            in_ist(uop.prs1) := true.B
           }
         }
       }
@@ -115,7 +117,6 @@ class RdtOneBit(implicit p: Parameters) extends RegisterDependencyTable {
           io.mark(port_idx).mark.valid := !in_ist(uop.prs2) // Only valid when RS1 is not already in IST
           io.mark(port_idx).mark.bits := rdt(uop.prs2)
           port_used := !in_ist(uop.prs2)
-          in_ist(uop.prs2) := true.B // Update in_ist
           // bypass rdt for previous insns written in same cycle
           for (j <- 0 until i) {
             val uop_j = io.update(j).uop
@@ -125,6 +126,9 @@ class RdtOneBit(implicit p: Parameters) extends RegisterDependencyTable {
               port_used := !uop_j_in_ist
               io.mark(port_idx).mark.bits := io.update(j).tag
             }
+          }
+          when (port_used) {
+            in_ist(uop.prs2) := true.B
           }
         }
       }

--- a/src/main/scala/lsc/RegisterDependencyTable.scala
+++ b/src/main/scala/lsc/RegisterDependencyTable.scala
@@ -58,8 +58,7 @@ class RdtOneBit(implicit p: Parameters) extends RegisterDependencyTable {
 
     // Mark source register 1
     when(valid && is_b) {
-      when(uop.lrs1_rtype === RT_FIX && uop.prs1 =/= 0.U)
-        {
+      when(uop.lrs1_rtype === RT_FIX && uop.prs1 =/= 0.U) {
         if (mark_port_idx < lscParams.rdtIstMarkWidth) {
           io.mark(mark_port_idx).mark.valid := !in_ist(uop.prs1) // Only valid when RS1 is not already in IST
           io.mark(mark_port_idx).mark.bits := rdt(uop.prs1)
@@ -78,8 +77,9 @@ class RdtOneBit(implicit p: Parameters) extends RegisterDependencyTable {
       }
 
       // Mark source register 2
-      when(uop.lrs2_rtype === RT_FIX && uop.prs2 =/= 0.U)
-      {
+      when(uop.lrs2_rtype === RT_FIX &&
+        uop.prs2 =/= 0.U &&
+        !(uop.uopc === uopSTA || uop.uopc === uopSTD) ) { //Dont mark RS2 of stores, since its the data generation
         if (mark_port_idx < lscParams.rdtIstMarkWidth) {
           io.mark(mark_port_idx).mark.valid := !in_ist(uop.prs2) // Only valid when RS1 is not already in IST
           io.mark(mark_port_idx).mark.bits := rdt(uop.prs2)
@@ -98,6 +98,7 @@ class RdtOneBit(implicit p: Parameters) extends RegisterDependencyTable {
       }
     }
   }
+}
 
 
 

--- a/src/main/scala/lsc/RegisterDependencyTable.scala
+++ b/src/main/scala/lsc/RegisterDependencyTable.scala
@@ -12,6 +12,18 @@ import boom.common._
   * @param
   */
 
+abstract class RegisterDependencyTable(implicit p: Parameters) extends BoomModule {
+  val lscParams = boomParams.loadSliceCore.get
+  val io = IO(new RdtIO)
+}
+
+
+class RdtIO(implicit p: Parameters) extends BoomBundle
+{
+  val update = Input(Vec(decodeWidth, new RdtUpdateSignals))
+  val mark = Output(Vec(boomParams.loadSliceCore.get.rdtIstMarkWidth, new IstMark))
+}
+
 class RdtUpdateSignals(implicit p: Parameters) extends BoomBundle
 {
   val valid = Bool()
@@ -19,22 +31,84 @@ class RdtUpdateSignals(implicit p: Parameters) extends BoomBundle
   val uop = new MicroOp
 }
 
-class RdtIO(implicit p: Parameters) extends BoomBundle
-{
-  val update = Input(Vec(decodeWidth, new RdtUpdateSignals))
-  val mark = Output(new IstMark)
-}
-
-class RegisterDependencyTable(implicit p: Parameters) extends BoomModule{
-  val io = IO(new RdtIO)
-
-  val LscParams = boomParams.loadSliceCore.get
-
-  val rdt = Reg(Vec(boomParams.numIntPhysRegisters, UInt(LscParams.ibda_tag_sz.W)))
+class RdtOneBit(implicit p: Parameters) extends RegisterDependencyTable {
+  val rdt = Reg(Vec(boomParams.numIntPhysRegisters, UInt(lscParams.ibda_tag_sz.W)))
+  val in_ist = RegInit(VecInit(Seq.fill(boomParams.numIntPhysRegisters)(false.B)))
   val commit_dst_valid = WireInit(VecInit(Seq.fill(decodeWidth)(false.B)))
 
   io.mark := DontCare
-  io.mark.mark.map(_.valid := false.B)
+  io.mark.map(_.mark.valid := false.B)
+
+  var mark_port_idx = 0
+
+  for (i <- 0 until decodeWidth) {
+    val uop = io.update(i).uop
+    val valid = io.update(i).valid
+    val tag = io.update(i).tag
+
+    val is_b = uop.is_lsc_b || uop.uopc === uopLD || uop.uopc === uopSTA || uop.uopc === uopSTD
+
+
+    // record pc of last insn that writes to reg
+    when(valid && uop.dst_rtype === RT_FIX && uop.pdst =/= 0.U) {
+      rdt(uop.pdst) := tag
+      in_ist(uop.pdst) := is_b
+      commit_dst_valid(i) := true.B
+    }
+
+    // Mark source register 1
+    when(valid && is_b) {
+      when(uop.lrs1_rtype === RT_FIX && uop.prs1 =/= 0.U)
+        {
+        if (mark_port_idx < lscParams.rdtIstMarkWidth) {
+          io.mark(mark_port_idx).mark.valid := !in_ist(uop.prs1) // Only valid when RS1 is not already in IST
+          io.mark(mark_port_idx).mark.bits := rdt(uop.prs1)
+          in_ist(uop.prs1) := true.B // Update in_ist
+          // bypass rdt for previous insns written in same cycle
+          for (j <- 0 until i) {
+            val uop_j = io.update(j).uop
+            val uop_j_in_ist = (uop_j.is_lsc_b || uop_j.uopc === uopLD || uop_j.uopc === uopSTA || uop_j.uopc === uopSTD)
+            when(commit_dst_valid(j) && uop_j.pdst === uop.prs1) {
+              io.mark(mark_port_idx).mark.valid := !uop_j_in_ist
+              io.mark(mark_port_idx).mark.bits := io.update(j).tag
+            }
+          }
+          mark_port_idx += 1
+        }
+      }
+
+      // Mark source register 2
+      when(uop.lrs2_rtype === RT_FIX && uop.prs2 =/= 0.U)
+      {
+        if (mark_port_idx < lscParams.rdtIstMarkWidth) {
+          io.mark(mark_port_idx).mark.valid := !in_ist(uop.prs2) // Only valid when RS1 is not already in IST
+          io.mark(mark_port_idx).mark.bits := rdt(uop.prs2)
+          in_ist(uop.prs2) := true.B // Update in_ist
+          // bypass rdt for previous insns written in same cycle
+          for (j <- 0 until i) {
+            val uop_j = io.update(j).uop
+            val uop_j_in_ist = (uop_j.is_lsc_b || uop_j.uopc === uopLD || uop_j.uopc === uopSTA || uop_j.uopc === uopSTD)
+            when(commit_dst_valid(j) && uop_j.pdst === uop.prs2) {
+              io.mark(mark_port_idx).mark.valid := !uop_j_in_ist
+              io.mark(mark_port_idx).mark.bits := io.update(j).tag
+            }
+          }
+          mark_port_idx += 1
+        }
+      }
+    }
+  }
+
+
+
+
+class RdtBasic(implicit p: Parameters) extends RegisterDependencyTable {
+
+  val rdt = Reg(Vec(boomParams.numIntPhysRegisters, UInt(lscParams.ibda_tag_sz.W)))
+  val commit_dst_valid = WireInit(VecInit(Seq.fill(decodeWidth)(false.B)))
+
+  io.mark := DontCare
+  io.mark.map(_.mark.valid := false.B)
 
   for(i <- 0 until decodeWidth){
 
@@ -53,24 +127,24 @@ class RegisterDependencyTable(implicit p: Parameters) extends BoomModule{
     // add pcs of dependent insns to ist
     when(valid && is_b){
       when(uop.lrs1_rtype === RT_FIX && uop.prs1 =/= 0.U){ //TODO: Remove use of logical register specifiers.
-        io.mark.mark(2*i).valid := true.B
-        io.mark.mark(2*i).bits := rdt(uop.prs1)
+        io.mark(2*i).mark.valid := true.B
+        io.mark(2*i).mark.bits := rdt(uop.prs1)
         // bypass rdt for previous insns committed in same cycle
         for (j <- 0 until i){
           val uop_j = io.update(j).uop
           when(commit_dst_valid(j) && uop_j.pdst === uop.prs1){
-            io.mark.mark(2*i).bits := io.update(j).tag
+            io.mark(2*i).mark.bits := io.update(j).tag
           }
         }
       }
       when(uop.lrs2_rtype === RT_FIX && uop.prs2 =/= 0.U){
-        io.mark.mark(2*i+1).valid := true.B
-        io.mark.mark(2*i+1).bits := rdt(uop.prs2)
+        io.mark(2*i+1).mark.valid := true.B
+        io.mark(2*i+1).mark.bits := rdt(uop.prs2)
         // bypass rdt for previous insns committed in same cycle
         for (j <- 0 until i){
           val uop_j = io.update(j).uop
           when(commit_dst_valid(j) && uop_j.pdst === uop.prs2){
-            io.mark.mark(2*i+1).bits := io.update(j).tag
+            io.mark(2*i+1).mark.bits := io.update(j).tag
           }
         }
       }


### PR DESCRIPTION
- Disallow Store Data Generating Instructions in IST (and thus keep them in the A-Q) Fix #18 
- Make RegisterDependencyTable an abstract base class
- RdtBasic is the original impl
- RdtOneBit is with 1 additional bit to store wether the instr who wrote to the reg is already in IST. To avoid duplicate writes. Fix #14 
- Make rdtIstMarkWidth a parameter. This is the number of mark ports between RDT and IST
- Utilize IST better for tag: inst+pc_lob. FIx #22 
