### PR TITLE
Eecs ntnu/wb pipelining

### DIFF
--- a/src/main/scala/common/parameters.scala
+++ b/src/main/scala/common/parameters.scala
@@ -101,7 +101,10 @@ case class BoomCoreParams(
   /* debug stuff */
   enableCommitLogPrintf: Boolean = false,
   enableBranchPrintf: Boolean = false,
-  enableMemtracePrintf: Boolean = false
+  enableMemtracePrintf: Boolean = false,
+
+  enableWritebackPipelining: Boolean = false,
+  issueAcquireUnderRelease: Boolean = false,
 
 // DOC include end: BOOM Parameters
 ) extends freechips.rocketchip.tile.CoreParams
@@ -236,6 +239,8 @@ trait HasBoomCoreParameters extends freechips.rocketchip.tile.HasCoreParameters
 
   val enableFastLoadUse = boomParams.enableFastLoadUse
   val enablePrefetching = boomParams.enablePrefetching
+  val enableWbPipelining = boomParams.enableWritebackPipelining
+  val issueAcquireUnderRelease = boomParams.issueAcquireUnderRelease
   val nLBEntries = dcacheParams.nMSHRs
 
   //************************************

--- a/src/main/scala/lsu/mshrs.scala
+++ b/src/main/scala/lsu/mshrs.scala
@@ -569,6 +569,19 @@ class BoomMSHRFile(implicit edge: TLEdgeOut, p: Parameters) extends BoomModule()
   val lb_read_arb  = Module(new Arbiter(new LineBufferReadReq, cfg.nMSHRs))
   val lb_write_arb = Module(new Arbiter(new LineBufferWriteReq, cfg.nMSHRs))
 
+  lb_read_arb.io.out.ready  := true.B
+  lb_write_arb.io.out.ready := true.B
+
+  val lb_read_data = WireInit(0.U(encRowBits.W))
+  when (lb_write_arb.io.out.fire()) {
+    lb.write(lb_write_arb.io.out.bits.lb_addr, lb_write_arb.io.out.bits.data)
+  }
+  when (lb_read_arb.io.out.fire()) {
+    lb_read_data := lb.read(lb_read_arb.io.out.bits.lb_addr)
+  }
+
+  /*
+  // Linebuffer write blocks read (old implementation)
   lb_read_arb.io.out.ready  := false.B
   lb_write_arb.io.out.ready := true.B
 
@@ -581,6 +594,8 @@ class BoomMSHRFile(implicit edge: TLEdgeOut, p: Parameters) extends BoomModule()
       lb_read_data := lb.read(lb_read_arb.io.out.bits.lb_addr)
     }
   }
+  */
+
   def widthMap[T <: Data](f: Int => T) = VecInit((0 until memWidth).map(f))
 
 


### PR DESCRIPTION
<!-- ******************************************************* -->
<!-- MAKE SURE TO READ ALL FIELDS FOR THE PR TO BE ADDRESSED -->
<!-- ******************************************************* -->

<!-- choose one -->
**Type of change**: new feature 

<!-- choose one -->
**Impact**:  new rtl

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
This PR includes two related additions. One is adding a pipelined writeback unit which improves memory bandwidth for eviction-heavy applications.  The second is adding an option for not issuing Tilelink acquires while a Tilelink release is in progress, which avoids a deadlock experienced while devoloping the pipelined writeback unit.